### PR TITLE
Add settings view and persistent user preferences

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -30,19 +30,28 @@
                         <StackPanel Grid.Row="0" Margin="0,50,0,0">
                             <StackPanel x:Name="btnWeather" 
                                         MouseLeftButtonDown="BtnWeather_MouseDown"
-                                        Margin="0,0,0,40" 
+                                        Margin="0,0,0,30" 
                                         Cursor="Hand" 
                                         Background="Transparent">
                                 <Image Source="/Images/weather.png" Width="25" HorizontalAlignment="Center" RenderOptions.BitmapScalingMode="HighQuality"/>
-                                <TextBlock Text="Weather" FontSize="12" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                <TextBlock Text="Home" FontSize="11" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5,0,0"/>
                             </StackPanel>
 
                             <StackPanel x:Name="btnCities" 
                                         MouseLeftButtonDown="BtnCities_MouseDown"
+                                        Margin="0,0,0,30"
                                         Cursor="Hand" 
                                         Background="Transparent">
                                 <Image Source="/Images/cities.png" Width="25" HorizontalAlignment="Center" RenderOptions.BitmapScalingMode="HighQuality"/>
-                                <TextBlock Text="Cities" FontSize="12" Foreground="#808080" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                <TextBlock Text="Cities" FontSize="11" Foreground="#808080" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5,0,0"/>
+                            </StackPanel>
+
+                            <StackPanel x:Name="btnSettings" 
+                                        MouseLeftButtonDown="BtnSettings_MouseDown"
+                                        Cursor="Hand" 
+                                        Background="Transparent">
+                                <TextBlock Text="⚙️" FontSize="24" HorizontalAlignment="Center" Foreground="#808080"/>
+                                <TextBlock Text="Settings" FontSize="11" Foreground="#808080" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5,0,0"/>
                             </StackPanel>
                         </StackPanel>
 
@@ -110,13 +119,13 @@
                                         </Grid.ColumnDefinitions>
                                         <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="20,0,0,0">
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock x:Name="txtCity" Text="İstanbul, Türkiye" FontSize="26" Foreground="White" FontWeight="Bold"/>
+                                                <TextBlock x:Name="txtCity" Text="Yükleniyor..." FontSize="26" Foreground="White" FontWeight="Bold"/>
                                                 <Button Click="btnFavorite_Click" Background="Transparent" BorderThickness="0" Margin="10,0,0,0" Cursor="Hand">
                                                     <TextBlock x:Name="txtStar" Text="☆" FontSize="24" Foreground="Gold"/>
                                                 </Button>
                                             </StackPanel>
-                                            <TextBlock x:Name="txtDate" Text="Tarih Bekleniyor..." FontSize="13" Foreground="LightGray" Margin="0,5,0,20"/>
-                                            <TextBlock x:Name="txtTemperature" Text="0°C" FontSize="50" Foreground="White" FontWeight="Bold"/>
+                                            <TextBlock x:Name="txtDate" Text="-" FontSize="13" Foreground="LightGray" Margin="0,5,0,20"/>
+                                            <TextBlock x:Name="txtTemperature" Text="-" FontSize="50" Foreground="White" FontWeight="Bold"/>
                                         </StackPanel>
                                         <Image Grid.Column="1" x:Name="imgMainWeather" Source="/Images/sun.png" Width="130" Height="130" HorizontalAlignment="Right" Margin="0,5,20,20"/>
                                     </Grid>
@@ -146,7 +155,6 @@
                                                 <lvc:Axis Visibility="Collapsed"/>
                                             </lvc:CartesianChart.AxisY>
                                         </lvc:CartesianChart>
-
                                     </Grid>
                                 </Border>
 
@@ -162,9 +170,6 @@
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Text="AIR CONDITIONS" Foreground="#808080" FontSize="12" FontWeight="Bold" VerticalAlignment="Center"/>
-                                            <Border Grid.Column="1" Background="#0099FF" CornerRadius="10" Padding="7,3">
-                                                <TextBlock Text="See more" Foreground="White" FontSize="10" FontWeight="Bold" VerticalAlignment="Center"/>
-                                            </Border>
                                         </Grid>
                                         <Grid Grid.Row="1">
                                             <Grid.ColumnDefinitions>
@@ -297,6 +302,57 @@
                                 </Border>
                             </Grid>
                         </Grid>
+                    </Grid>
+
+                    <Grid x:Name="SettingsView" Visibility="Collapsed">
+                        <Border Background="#202b3b" CornerRadius="20" Margin="50">
+                            <Grid Margin="30">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0" Text="Settings" FontSize="28" FontWeight="Bold" Foreground="White" Margin="0,0,0,20"/>
+
+                                <Separator Grid.Row="1" Background="#3a4b61" Margin="0,0,0,20"/>
+
+                                <StackPanel Grid.Row="2" Margin="0,0,0,20">
+                                    <TextBlock Text="Default City (Startup)" Foreground="#A0A0A0" FontSize="14" Margin="0,0,0,5"/>
+                                    <Border Background="#151e2b" CornerRadius="10" Height="40">
+                                        <TextBox x:Name="txtDefaultCity" 
+                                                 Foreground="White" 
+                                                 Background="Transparent" 
+                                                 BorderThickness="0" 
+                                                 VerticalAlignment="Center" 
+                                                 FontSize="16" 
+                                                 Margin="10,0,10,0"
+                                                 CaretBrush="White"/>
+                                    </Border>
+                                    <TextBlock Text="Application will load this city when opened." Foreground="#606060" FontSize="12" Margin="5,5,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel Grid.Row="3">
+                                    <TextBlock Text="Preferred Units" Foreground="#A0A0A0" FontSize="14" Margin="0,0,0,10"/>
+                                    <StackPanel Orientation="Horizontal">
+                                        <RadioButton x:Name="rbMetric" Content="Metric (°C, km/h)" Foreground="White" FontSize="16" Margin="0,0,20,0" IsChecked="True"/>
+                                        <RadioButton x:Name="rbImperial" Content="Imperial (°F, mph)" Foreground="White" FontSize="16"/>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <Button Grid.Row="4" Click="BtnSaveSettings_Click" HorizontalAlignment="Right" Width="120" Height="40">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border Background="#0099FF" CornerRadius="10">
+                                                <TextBlock Text="Save Changes" Foreground="White" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                            </Border>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
+                        </Border>
                     </Grid>
 
                 </Grid>


### PR DESCRIPTION
Introduced a Settings view in the UI for configuring default city and preferred units. Added AppSettings class and logic to load and save user preferences to a config file in AppData. Updated UI and event handlers to support switching between Weather, Cities, and Settings views, and to apply saved preferences on startup.