### PR TITLE
Add click handler to favorite city cards

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -298,7 +298,10 @@
                                             </ItemsControl.ItemsPanel>
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <Border Width="230" Height="110" CornerRadius="20" Margin="10">
+                                                    <Border Width="230" Height="110" CornerRadius="20" Margin="10" 
+                                                            Cursor="Hand"
+                                                            MouseLeftButtonDown="BtnFavoriteCard_Click"
+                                                            Tag="{Binding CityName}">
                                                         <Border.Background>
                                                             <ImageBrush ImageSource="{Binding BackgroundPath}" Stretch="UniformToFill"/>
                                                         </Border.Background>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -76,6 +76,19 @@ namespace SkyCast
             GetWeatherData(_lastCity);
         }
 
+        private void BtnFavoriteCard_Click(object sender, MouseButtonEventArgs e)
+        {
+            var border = sender as Border;
+            if (border?.Tag is string cityName)
+            {
+                GetWeatherData(cityName);
+                WeatherView.Visibility = Visibility.Visible;
+                CitiesView.Visibility = Visibility.Collapsed;
+                SettingsView.Visibility = Visibility.Collapsed;
+                UpdateNavColors("Home");
+            }
+        }
+
         private void UpdateNavColors(string activePage)
         {
             var grayBrush = new SolidColorBrush(Color.FromRgb(128, 128, 128));


### PR DESCRIPTION
Favorite city cards in the UI are now clickable. Clicking a card triggers weather data loading for the selected city and updates the view accordingly by showing the weather view and hiding others.